### PR TITLE
separate hackage per package

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Add dependencies to haskell.nix project via `extra-hackages` and `extra-hackage-
 
 ```nix
 let
-  myHackage = mkHackagesFor system compiler-nix-name [ ./mydep ./mydepdep ];
+  myHackages = mkHackagesFor system compiler-nix-name [ ./mydep ./mydepdep ];
 in
 cabalProject {
   inherit (myHackages) extra-hackages extra-hackage-tarballs modules;

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 Add dependencies to haskell.nix project via `extra-hackages` and `extra-hackage-tarballs`.
+
+
+```nix
+let
+  myHackage = mkHackagesFor system compiler-nix-name [ ./mydep ./mydepdep ];
+in
+cabalProject {
+  inherit (myHackages) extra-hackages extra-hackage-tarballs modules;
+  # ...
+};
+```

--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1653354979,
-        "narHash": "sha256-9plpFM3DkPb13FW25LVyfCpqnzs5nzMMWw42SOZpzGE=",
+        "lastModified": 1658106754,
+        "narHash": "sha256-rYxCkPJwyRuUJVw/XXqXHzqHZ4DKYcOQKKmTzVF/8Dc=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "b63711c848a8d2ec8ae189ad291ce54bb041874d",
+        "rev": "a5393328352ea96bf4be2c78b8cac2478fec9de9",
         "type": "github"
       },
       "original": {
@@ -151,16 +151,17 @@
         "nixpkgs-2003": "nixpkgs-2003",
         "nixpkgs-2105": "nixpkgs-2105",
         "nixpkgs-2111": "nixpkgs-2111",
+        "nixpkgs-2205": "nixpkgs-2205",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1653394713,
-        "narHash": "sha256-zPiZPoPn37t71QcpYjImboI9WV8ctXCcHPPhV++O+pI=",
+        "lastModified": 1658106909,
+        "narHash": "sha256-eQso2VHbQBxGBKE+OR27EjWdpAHNsiDvSE0MUPwk3BI=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "449d80f722a49e6bb893dbc8533e9ec2d4bd7072",
+        "rev": "8955cbd1e12773e0b4a34f8e8924b0988ddfe65a",
         "type": "github"
       },
       "original": {
@@ -294,11 +295,11 @@
     },
     "nixpkgs-2105": {
       "locked": {
-        "lastModified": 1645296114,
-        "narHash": "sha256-y53N7TyIkXsjMpOG7RhvqJFGDacLs9HlyHeSTBioqYU=",
+        "lastModified": 1655034179,
+        "narHash": "sha256-rf1/7AbzuYDw6+8Xvvf3PtEOygymLBrFsFxvext5ZjI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "530a53dcbc9437363471167a5e4762c5fcfa34a1",
+        "rev": "046ee4af7a9f016a364f8f78eeaa356ba524ac31",
         "type": "github"
       },
       "original": {
@@ -310,16 +311,32 @@
     },
     "nixpkgs-2111": {
       "locked": {
-        "lastModified": 1648744337,
-        "narHash": "sha256-bYe1dFJAXovjqiaPKrmAbSBEK5KUkgwVaZcTbSoJ7hg=",
+        "lastModified": 1656782578,
+        "narHash": "sha256-1eMCBEqJplPotTo/SZ/t5HU6Sf2I8qKlZi9MX7jv9fw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0a58eebd8ec65ffdef2ce9562784123a73922052",
+        "rev": "573603b7fdb9feb0eb8efc16ee18a015c667ab1b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2205": {
+      "locked": {
+        "lastModified": 1657876628,
+        "narHash": "sha256-URmf0O2cQ/3heg2DJOeLyU/JmfVMqG4X5t9crQXMaeY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549d82bdd40f760a438c3c3497c1c61160f3de55",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -341,11 +358,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1648219316,
-        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
+        "lastModified": 1657888067,
+        "narHash": "sha256-GnwJoFBTPfW3+mz7QEeJEEQ9OMHZOiIJ/qDhZxrlKh8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
+        "rev": "65fae659e31098ca4ac825a6fef26d890aaf3f4e",
         "type": "github"
       },
       "original": {
@@ -384,11 +401,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1653355076,
-        "narHash": "sha256-mQdOgAyFkLUJBPrVDZmZQ2JRtgHKOQkil//SDdcjP1U=",
+        "lastModified": 1658106847,
+        "narHash": "sha256-xcq/FgP1eNxaq7BaI+k0bkXfy+MFGib5I44VGGFQZdQ=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "71b16ca68d6acd639121db43238896357fe53f54",
+        "rev": "0fbfc3a3fb735e6bd5c81f614d8ed5308e501496",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -188,14 +188,18 @@
         default = ((pkgsFor system).myapp.flake { }).devShell;
       });
 
+      checks = perSystem (system: {
+        default = self.packages.${system}.default;
+      });
+
       # export
       inherit mkPackageSpec mkPackageTarballFor mkHackageDirFor mkHackageTarballFromDirsFor mkHackageTarballFor mkHackageNixFor mkHackageFromSpecFor mkHackagesFromSpecFor mkHackageFor mkHackagesFor;
+      overlay = perSystem overlayFor;
 
       # for debugging
       myapp = perSystem (system: (pkgsFor system).myapp);
       haskell-nix = perSystem (system: (pkgsFor system).haskell-nix);
       myHackages = perSystem (system: (pkgsFor system).myHackages);
 
-      overlay = perSystem overlayFor;
     };
 }

--- a/myapp/Main.hs
+++ b/myapp/Main.hs
@@ -1,3 +1,5 @@
+import MyDep (mydep)
+
 main :: IO ()
 main =
-    putStrLn "Hello, World!"
+    if mydep == () then putStrLn "Hello, World!" else return ()

--- a/mydep/MyDep.hs
+++ b/mydep/MyDep.hs
@@ -1,4 +1,6 @@
 module MyDep (mydep) where
 
+import MyDepDep (mydepdep)
+
 mydep :: ()
-mydep = ()
+mydep = mydepdep

--- a/mydepdep/MyDepDep.hs
+++ b/mydepdep/MyDepDep.hs
@@ -1,0 +1,4 @@
+module MyDepDep (mydepdep) where
+
+mydepdep :: ()
+mydepdep = ()

--- a/mydepdep/mydepdep.cabal
+++ b/mydepdep/mydepdep.cabal
@@ -1,4 +1,4 @@
-name: mydep
+name: mydepdep
 version: 0.0.1
 cabal-version: >= 1.2
 
@@ -8,9 +8,8 @@ custom-setup
 
 library
     exposed-modules:
-        MyDep
+        MyDepDep
     setup-depends:
         Cabal
     build-depends:
         base
-        , mydepdep


### PR DESCRIPTION
- creates separate hackage per package so only changed dependencies are rebuilt
- easier to use
```
inherit (myHackages) extra-hackages extra-hackage-tarballs modules;
```
- is a monoid so extensible
- prefixes hackage names with `_` to hack priority
